### PR TITLE
chore: allow all CORS origins to access both swagger and API-s for now

### DIFF
--- a/TeamGPTInventory2025/Program.cs
+++ b/TeamGPTInventory2025/Program.cs
@@ -64,6 +64,17 @@ builder.Services.AddAuthentication(options =>
     };
 });
 
+// Configure CORS to allow any origin to access the APIs
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy("AllowAll", policy =>
+    {
+        policy.AllowAnyOrigin()
+              .AllowAnyMethod()
+              .AllowAnyHeader();
+    });
+});
+
 var app = builder.Build();
 
 using (var scope = app.Services.CreateScope())
@@ -116,6 +127,10 @@ using (var scope = app.Services.CreateScope())
 }
 
 // Configure the HTTP request pipeline.
+
+
+// Enable CORS using the configured policy
+app.UseCors("AllowAll");
 
 if (app.Environment.IsDevelopment())
 {


### PR DESCRIPTION
This allows the Swagger JSON (normally at https://localhost:7122/swagger/v1/swagger.json) to be requested by all origins, including the App Builder app (https://my.appbuilder.dev) so it can be loaded in the New Data source dialogs :)